### PR TITLE
Change the scipy version from >=1.14.0 to ==1.10.1 in pyproject.toml and update

### DIFF
--- a/.github/workflows/RLearn_pytest.yml
+++ b/.github/workflows/RLearn_pytest.yml
@@ -8,6 +8,7 @@ on:
       - 'test/data/dss/*'
       - 'test/data/stb_skc/*'
       - '.github/workflows/RLearn_pytest.yml'
+      - 'pyproject.toml'
 
 # Add these permissions
 permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "pydantic>=2.9.0",
     "pytorch-lightning>=2.4.0",
     "scikit-learn>=1.5.0",
-    "scipy>=1.14.0",
+    "scipy==1.10.1",
     "torchmetrics==1.4.0",
     "tqdm",
     "cloudpickle>=3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openstarlab_rlearn"
-version = "0.1.21"
+version = "0.1.25"
 description = "openstarlab rlearn modeliing package"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
This pull request updates the package version and makes a change to the `scipy` dependency specification in the `pyproject.toml` file.

Dependency updates:

* Changed the `scipy` dependency from a minimum version (`>=1.14.0`) to an exact version (`==1.10.1`) to ensure compatibility and reproducibility.

Version bump:

* Updated the package version from `0.1.21` to `0.1.25` to reflect the new release.