### PR TITLE
Remove gameid length restriction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openstarlab_rlearn"
-version = "0.1.27"
+version = "0.1.28"
 description = "openstarlab rlearn modeliing package"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/rlearn/sports/main_class.py
+++ b/rlearn/sports/main_class.py
@@ -18,8 +18,8 @@ if __name__ == "__main__":
     # test split_data
     RLearn_Model(
         state_def="PVS",
-        input_path=os.getcwd() + "/test/data/datastadium/",
-        output_path=os.getcwd() + "/test/data/datastadium/split/",
+        input_path=os.getcwd() + "/test/data/fifawc/preprocess_data/",
+        output_path=os.getcwd() + "/test/data/fifawc/preprocess_data/split/",
     ).split_train_test()
 
     # test preprocess observation data

--- a/rlearn/sports/soccer/main_class_soccer/main.py
+++ b/rlearn/sports/soccer/main_class_soccer/main.py
@@ -69,7 +69,7 @@ class rlearn_model_soccer:
         output_dir.mkdir(parents=True, exist_ok=True)
 
         if pytest:
-            game_ids = [str(p.name) for p in Path(self.input_path).glob("*") if p.is_dir()]
+            game_ids = [str(p.name) for p in Path(self.input_path).glob("*") if p.is_dir() and p.name.isdigit()]
 
             train_dataset = load_dataset(
                 "json",
@@ -78,7 +78,9 @@ class rlearn_model_soccer:
                 num_proc=self.num_process,
             )
         else:
-            game_ids = [str(p.name) for p in Path(self.input_path).glob("*") if p.is_dir()]
+            game_ids = [str(p.name) for p in Path(self.input_path).glob("*") if p.is_dir() and p.name.isdigit()]
+            if len(game_ids) == 0:
+                raise ValueError(f"No numeric game directories found in {self.input_path}. Please check if the correct data path is specified.")
             train_game_ids, test_val_game_ids = train_test_split(game_ids, test_size=0.5, random_state=self.seed)
             test_game_ids, val_game_ids = train_test_split(test_val_game_ids, test_size=0.1, random_state=self.seed)
 

--- a/rlearn/sports/soccer/main_class_soccer/main.py
+++ b/rlearn/sports/soccer/main_class_soccer/main.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from pathlib import Path
 import os
 from typing import Any, Dict
@@ -70,7 +69,7 @@ class rlearn_model_soccer:
         output_dir.mkdir(parents=True, exist_ok=True)
 
         if pytest:
-            game_ids = [str(p.name) for p in Path(self.input_path).glob("*") if re.match(r"\d{10}", p.name)]
+            game_ids = [str(p.name) for p in Path(self.input_path).glob("*") if p.is_dir()]
 
             train_dataset = load_dataset(
                 "json",
@@ -79,7 +78,7 @@ class rlearn_model_soccer:
                 num_proc=self.num_process,
             )
         else:
-            game_ids = [str(p.name) for p in Path(self.input_path).glob("*") if re.match(r"\d{10}", p.name)]
+            game_ids = [str(p.name) for p in Path(self.input_path).glob("*") if p.is_dir()]
             train_game_ids, test_val_game_ids = train_test_split(game_ids, test_size=0.5, random_state=self.seed)
             test_game_ids, val_game_ids = train_test_split(test_val_game_ids, test_size=0.1, random_state=self.seed)
 


### PR DESCRIPTION
This pull request updates the data path for test cases and improves the logic for identifying game directories in the soccer model, making the code more robust and maintainable. It also bumps the package version and removes an unused import.

**Data path and directory identification improvements:**

* Updated the test data input and output paths in `main_class.py` to use the `fifawc/preprocess_data` directory, ensuring tests use the correct dataset location.
* Replaced the use of regular expressions with a more reliable check for numeric directory names in `main.py`, using `p.is_dir()` and `p.name.isdigit()` for game directory identification. [[1]](diffhunk://#diff-e508bea29ff9ac63ff24d6fe2a5efb54b271c5ce42b3721f44570c587e28a0b0L73-R72) [[2]](diffhunk://#diff-e508bea29ff9ac63ff24d6fe2a5efb54b271c5ce42b3721f44570c587e28a0b0L82-R83)
* Added error handling to raise a `ValueError` if no numeric game directories are found, helping users diagnose data path issues more easily.

**Code maintenance:**

* Removed the unused `re` import from `main.py` to clean up the codebase.

**Version update:**

* Bumped the package version from `0.1.27` to `0.1.28` in `pyproject.toml` to reflect these changes.